### PR TITLE
Add babel transform-class-properties support

### DIFF
--- a/ui/.babelrc
+++ b/ui/.babelrc
@@ -5,6 +5,7 @@
   ],
   "plugins": [
     "transform-object-rest-spread",
+    "transform-class-properties",
     ["import", { "libraryName": "antd", "libraryDirectory": "es", "style": "css" }]
   ]
 }

--- a/ui/.eslintrc
+++ b/ui/.eslintrc
@@ -11,7 +11,7 @@
   "extends": "airbnb",
   "rules": {
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
-    "react/prop-types": 0,
+    "react/prop-types": 1,
     "import/prefer-default-export": 0,
     "linebreak-style": 0,
     "jsx-a11y/anchor-is-valid": 0

--- a/ui/package.json
+++ b/ui/package.json
@@ -34,6 +34,7 @@
     "@storybook/addon-actions": "^3.3.12",
     "@storybook/react": "^3.3.12",
     "antd": "^3.1.3",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "bluebird": "^3.5.1",
     "echarts": "^4.0.2",

--- a/ui/src/component/dao-chart.js
+++ b/ui/src/component/dao-chart.js
@@ -1,9 +1,18 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactEcharts from 'echarts-for-react';
 import _ from 'lodash';
 import convert from '../converters';
 
 export default class extends Component {
+  static defaultProps = {
+    meta: {},
+  }
+
+  static propTypes = {
+    meta: PropTypes.objectOf(PropTypes.any),
+  }
+
   constructor(props) {
     super(props);
     this.state = { option: {} };


### PR DESCRIPTION
So below sytax is allowed:
```
export default class extends Component {
  static defaultProps = {
    meta: {},
  }
 
  static propTypes = {
    meta: PropTypes.objectOf(PropTypes.any),
  }

  state = {};
  
  onChange = (event) => {
    ...
  }
}
```