### PR TITLE
Add pie chart component

### DIFF
--- a/ui/.storybook/config.js
+++ b/ui/.storybook/config.js
@@ -2,6 +2,7 @@ import { configure } from '@storybook/react';
 
 function loadStories() {
   require('../stories/index.js');
+  require('../stories/pie.js');
   // You can require as many stories as you need.
 }
 

--- a/ui/src/component/pie.js
+++ b/ui/src/component/pie.js
@@ -1,0 +1,102 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import ReactEcharts from 'echarts-for-react';
+import _ from 'lodash';
+
+export default class Pie extends PureComponent {
+  static propTypes = {
+    data: PropTypes.arrayOf(PropTypes.object),
+    percent: PropTypes.number,
+  }
+
+  static defaultProps = {
+    data: null,
+    percent: null,
+  }
+
+  render() {
+    const { data, percent } = this.props;
+    if (_.isEmpty(data) && _.isNull(percent)) {
+      return null;
+    }
+
+    const option = {
+      series: [
+        {
+          type: 'pie',
+          radius: ['50%', '70%'],
+          hoverOffset: 0,
+          labelLine: {
+            normal: {
+              show: false,
+            },
+          },
+          data: [
+            {
+              value: percent,
+              itemStyle: {
+                normal: {
+                  color: '#58afff',
+                },
+              },
+            },
+            {
+              value: _.max([100 - percent, 0]),
+              itemStyle: {
+                normal: {
+                  color: '#f2f4f6',
+                },
+                emphasis: {
+                  color: '#f8f8f8',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    // const option = {
+    //   tooltip: {
+    //     trigger: 'item',
+    //     formatter: "{a} <br/>{b}: {c} ({d}%)"
+    //   },
+    //   legend: {
+    //     orient: 'vertical',
+    //     x: 'left',
+    //     data: ['直接访问', '邮件营销', '联盟广告', '视频广告', '搜索引擎']
+    //   },
+    //   series: [
+    //     {
+    //       name: '访问来源',
+    //       type: 'pie',
+    //       radius: ['50%', '70%'],
+    //       avoidLabelOverlap: false,
+    //       label: {
+    //         normal: {
+    //           show: false,
+    //           position: 'center'
+    //         },
+    //         emphasis: {
+    //           show: true,
+    //           textStyle: {
+    //             fontSize: '30',
+    //             fontWeight: 'bold'
+    //           }
+    //         }
+    //       },
+    //       labelLine: {
+    //         normal: {
+    //           show: false
+    //         }
+    //       },
+    //       data,
+    //     }
+    //   ]
+    // };
+
+    return (
+      <ReactEcharts option={option} />
+    );
+  }
+}

--- a/ui/src/component/pie.js
+++ b/ui/src/component/pie.js
@@ -7,93 +7,111 @@ export default class Pie extends PureComponent {
   static propTypes = {
     data: PropTypes.arrayOf(PropTypes.object),
     percent: PropTypes.number,
+    title: PropTypes.string,
+    subTitle: PropTypes.string,
+    hasLegend: PropTypes.bool,
   }
 
   static defaultProps = {
     data: null,
     percent: null,
+    title: '',
+    subTitle: '',
+    hasLegend: false,
   }
 
   render() {
-    const { data, percent } = this.props;
+    const {
+      data,
+      percent,
+      title,
+      subTitle,
+      hasLegend,
+    } = this.props;
     if (_.isEmpty(data) && _.isNull(percent)) {
       return null;
     }
 
-    const option = {
+    let option = {
+      title: {
+        text: title,
+        subtext: subTitle,
+        x: 'center',
+        y: 'center',
+        textStyle: {
+          fontSize: '30',
+          fontWeight: 'bold',
+        },
+      },
       series: [
         {
           type: 'pie',
           radius: ['50%', '70%'],
           hoverOffset: 0,
+          label: {
+            normal: {
+              show: false,
+            },
+          },
           labelLine: {
             normal: {
               show: false,
             },
           },
-          data: [
-            {
-              value: percent,
-              itemStyle: {
-                normal: {
-                  color: '#58afff',
-                },
-              },
-            },
-            {
-              value: _.max([100 - percent, 0]),
-              itemStyle: {
-                normal: {
-                  color: '#f2f4f6',
-                },
-                emphasis: {
-                  color: '#f8f8f8',
-                },
-              },
-            },
-          ],
         },
       ],
     };
-
-    // const option = {
-    //   tooltip: {
-    //     trigger: 'item',
-    //     formatter: "{a} <br/>{b}: {c} ({d}%)"
-    //   },
-    //   legend: {
-    //     orient: 'vertical',
-    //     x: 'left',
-    //     data: ['直接访问', '邮件营销', '联盟广告', '视频广告', '搜索引擎']
-    //   },
-    //   series: [
-    //     {
-    //       name: '访问来源',
-    //       type: 'pie',
-    //       radius: ['50%', '70%'],
-    //       avoidLabelOverlap: false,
-    //       label: {
-    //         normal: {
-    //           show: false,
-    //           position: 'center'
-    //         },
-    //         emphasis: {
-    //           show: true,
-    //           textStyle: {
-    //             fontSize: '30',
-    //             fontWeight: 'bold'
-    //           }
-    //         }
-    //       },
-    //       labelLine: {
-    //         normal: {
-    //           show: false
-    //         }
-    //       },
-    //       data,
-    //     }
-    //   ]
-    // };
+    if (!_.isNull(percent)) {
+      option = _.defaultsDeep({
+        series: [
+          {
+            data: [
+              {
+                value: percent,
+                itemStyle: {
+                  normal: {
+                    color: '#58afff',
+                  },
+                },
+              },
+              {
+                value: _.max([100 - percent, 0]),
+                itemStyle: {
+                  normal: {
+                    color: '#f2f4f6',
+                  },
+                  emphasis: {
+                    color: '#f8f8f8',
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      }, option);
+    } else {
+      option = _.defaultsDeep({
+        tooltip: {
+          trigger: 'item',
+          formatter: '{a} <br/>{b}: {c} ({d}%)',
+        },
+        legend: hasLegend ?
+          {
+            orient: 'vertical',
+            x: 'right',
+            y: 'center',
+            data: _.map(data, 'name'),
+          } :
+          {
+            show: false,
+          },
+        series: [
+          {
+            data,
+          },
+        ],
+      }, option);
+    }
 
     return (
       <ReactEcharts option={option} />

--- a/ui/stories/pie.js
+++ b/ui/stories/pie.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import Pie from '../src/component/pie';
+
+const data = [
+  { value: 335, name: '直接访问' },
+  { value: 310, name: '邮件营销' },
+  { value: 234, name: '联盟广告' },
+  { value: 135, name: '视频广告' },
+  { value: 1548, name: '搜索引擎' },
+];
+
+
+storiesOf('Pie Chart', module)
+  .add('pie chart - percent', () => (
+    <Pie percent={28} title="28%" subTitle="fast food" height={140} />
+  ))
+  .add('pie chart - data', () => (
+    <Pie percent={28} />
+  ));

--- a/ui/stories/pie.js
+++ b/ui/stories/pie.js
@@ -13,8 +13,11 @@ const data = [
 
 storiesOf('Pie Chart', module)
   .add('pie chart - percent', () => (
-    <Pie percent={28} title="28%" subTitle="fast food" height={140} />
+    <Pie percent={28} title="28%" subTitle="fast food" />
   ))
   .add('pie chart - data', () => (
-    <Pie percent={28} />
+    <Pie data={data} title="$15781" subTitle="revenue" />
+  ))
+  .add('pie chart - data - hasLegend', () => (
+    <Pie hasLegend data={data} title="$15781" subTitle="revenue" />
   ));


### PR DESCRIPTION
### Change
1. Add pie chart component, which
    * Align props with [antd pie chart](https://pro.ant.design/components/Charts)
    * Support 2 types of data: a single number of percent, or an object array of data

2. Add 3 demos for the component

### How to verify
Run `yarn storybook` to see the demos