### PR TITLE
Add horizontal bar and ordered bar

### DIFF
--- a/ui/src/component/horizontal-bar.js
+++ b/ui/src/component/horizontal-bar.js
@@ -1,0 +1,41 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import ReactEcharts from 'echarts-for-react';
+import _ from 'lodash';
+
+export default class HorizontalBar extends PureComponent {
+  static propTypes = {
+    source: PropTypes.arrayOf(PropTypes.array).isRequired,
+  }
+
+  render() {
+    const dimensions = _.first(this.props.source);
+    if (_.isEmpty(dimensions)) {
+      return null;
+    }
+
+    const option = {
+      legend: {},
+      tooltip: {
+        trigger: 'axis',
+        axisPointer: {
+          type: 'shadow',
+        },
+      },
+      dataset: {
+        source: this.props.source,
+        dimensions,
+      },
+      yAxis: { type: 'category' },
+      xAxis: { type: 'value' },
+      series: _.map(dimensions.slice(1), dimension => ({
+        type: 'bar',
+        name: dimension,
+      })),
+    };
+
+    return (
+      <ReactEcharts option={option} {...this.props} />
+    );
+  }
+}

--- a/ui/src/component/ordered-bar.js
+++ b/ui/src/component/ordered-bar.js
@@ -15,16 +15,16 @@ export default class OrderedBar extends PureComponent {
       return null;
     }
 
-    const [dimension, metric] = dimensions;
+    const [y, x] = dimensions;
 
     const newSource = _.reduce(this.props.source.slice(1), (memo, data) => [
       ...memo,
       {
-        [dimension]: _.first(data),
-        [metric]: _.last(data),
+        [y]: _.first(data),
+        [x]: _.last(data),
       },
     ], []);
-    const sortedSource = _.sortBy(newSource, metric);
+    const sortedSource = _.sortBy(newSource, x);
 
     const option = {
       legend: {},
@@ -42,7 +42,7 @@ export default class OrderedBar extends PureComponent {
       xAxis: { type: 'value' },
       series: {
         type: 'bar',
-        name: metric,
+        name: x,
       },
     };
 

--- a/ui/src/component/ordered-bar.js
+++ b/ui/src/component/ordered-bar.js
@@ -1,0 +1,53 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import ReactEcharts from 'echarts-for-react';
+import _ from 'lodash';
+
+export default class OrderedBar extends PureComponent {
+  static propTypes = {
+    source: PropTypes.arrayOf(PropTypes.array).isRequired,
+  }
+
+  render() {
+    const dimensions = _.first(this.props.source);
+    // ordered chart only supports single metric and single dimension
+    if (_.isEmpty(dimensions) || _.size(dimensions) > 2) {
+      return null;
+    }
+
+    const [dimension, metric] = dimensions;
+
+    const newSource = _.reduce(this.props.source.slice(1), (memo, data) => [
+      ...memo,
+      {
+        [dimension]: _.first(data),
+        [metric]: _.last(data),
+      },
+    ], []);
+    const sortedSource = _.sortBy(newSource, metric);
+
+    const option = {
+      legend: {},
+      tooltip: {
+        trigger: 'axis',
+        axisPointer: {
+          type: 'shadow',
+        },
+      },
+      dataset: {
+        source: sortedSource,
+        dimensions,
+      },
+      yAxis: { type: 'category' },
+      xAxis: { type: 'value' },
+      series: {
+        type: 'bar',
+        name: metric,
+      },
+    };
+
+    return (
+      <ReactEcharts option={option} {...this.props} />
+    );
+  }
+}

--- a/ui/stories/bar.stories.js
+++ b/ui/stories/bar.stories.js
@@ -1,9 +1,25 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import Bar from '../src/component/bar';
+import HorizontalBar from '../src/component/horizontal-bar';
+import OrderedBar from '../src/component/ordered-bar';
+
 import { source } from './data';
+
+const sourceForOrderedBar = [
+  ['framework', 'star'],
+  ['React', 1000],
+  ['Angularjs', 1020],
+  ['Backbone', 50],
+];
 
 storiesOf('Bar Chart', module)
   .add('Simple bar', () => (
     <Bar source={source} />
+  ))
+  .add('Simple horizontal bar', () => (
+    <HorizontalBar source={source} />
+  ))
+  .add('Simple ordered bar', () => (
+    <OrderedBar source={sourceForOrderedBar} />
   ));


### PR DESCRIPTION
```How to verify```
Run ```yarn storybook```, and the demos are located under bar category

Ordered bar is used for single metric and single dimension, the component will sort the passed in source.
Horizontal just draws the bar horizontally.