### PR TITLE
Refactor line chart to increase extensibility, add cumulative chart based on line chart

### DIFF
--- a/ui/src/component/cumulative.js
+++ b/ui/src/component/cumulative.js
@@ -1,0 +1,31 @@
+import _ from 'lodash';
+import Line from './line';
+
+
+export default class Cumulative extends Line {
+  getSource() {
+    const rawSource = this.props.source;
+    const paddingZero = _.chain(rawSource)
+      .first()
+      .size()
+      .range()
+      .map(() => 0)
+      .value();
+    return [
+      rawSource[0],
+      paddingZero,
+      ...rawSource.slice(1),
+    ];
+  }
+
+  getOption() {
+    return _.defaultsDeep({
+      xAxis: {
+        axisLabel: {
+          showMinLabel: false,
+          align: 'right',
+        },
+      },
+    }, super.getOption());
+  }
+}

--- a/ui/src/component/line.js
+++ b/ui/src/component/line.js
@@ -18,14 +18,13 @@ export default class Line extends PureComponent {
     hasDataZoom: false,
   }
 
-  getOption() {
-    const {
-      source,
-    } = this.props;
-    const dimensions = _.first(source);
+  getSource() {
+    return this.props.source;
+  }
 
+  getOption() {
     const dataOption = getDataOption({
-      source,
+      source: this.getSource(),
       defaultSeriesOpt: {
         type: 'line',
       },
@@ -36,10 +35,6 @@ export default class Line extends PureComponent {
       legend: {},
       tooltip: {
         trigger: 'axis',
-      },
-      dataset: {
-        source: this.props.source,
-        dimensions,
       },
       yAxis: {
         type: 'value',
@@ -73,11 +68,13 @@ export default class Line extends PureComponent {
   }
 
   render() {
-    validate(this.props.source);
+    const source = this.getSource();
+
+    validate(source);
     const onEvents = {
       click: args =>
         this.props.onSlicerChange(_.defaults(
-          {}, { dataObj: _.zipObject(_.first(this.props.source), args.data) },
+          {}, { dataObj: _.zipObject(_.first(source), args.data) },
           args,
         )),
     };

--- a/ui/src/component/line.js
+++ b/ui/src/component/line.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import ReactEcharts from 'echarts-for-react';
 import _ from 'lodash';
-import { validate, getDimensionSeries } from '../utils';
+import { validate, getDataOption } from '../utils';
 
 export default class Line extends PureComponent {
   static propTypes = {
@@ -18,10 +18,20 @@ export default class Line extends PureComponent {
     hasDataZoom: false,
   }
 
-  render() {
-    validate(this.props.source);
-    const dimensions = _.first(this.props.source);
-    const option = {
+  getOption() {
+    const {
+      source,
+    } = this.props;
+    const dimensions = _.first(source);
+
+    const dataOption = getDataOption({
+      source,
+      defaultSeriesOpt: {
+        type: 'line',
+      },
+    });
+
+    return _.defaultsDeep({
       title: this.props.title,
       legend: {},
       tooltip: {
@@ -38,10 +48,6 @@ export default class Line extends PureComponent {
         type: 'category',
         boundaryGap: false,
       },
-      series: getDimensionSeries({
-        dimensions,
-        type: 'line',
-      }),
       dataZoom: this.props.hasDataZoom ? [{
         type: 'slider',
         showDataShadow: false,
@@ -60,8 +66,14 @@ export default class Line extends PureComponent {
       }, {
         type: 'inside',
       }] : [],
-    };
+    }, {
+      xAxis: dataOption.axis,
+      series: dataOption.series,
+    });
+  }
 
+  render() {
+    validate(this.props.source);
     const onEvents = {
       click: args =>
         this.props.onSlicerChange(_.defaults(
@@ -72,7 +84,7 @@ export default class Line extends PureComponent {
 
     return (
       <ReactEcharts
-        option={option}
+        option={this.getOption()}
         notMerge={true} //eslint-disable-line
         onEvents={onEvents}
         {...this.props}

--- a/ui/src/component/target-line.js
+++ b/ui/src/component/target-line.js
@@ -10,13 +10,11 @@ export default class TargetLine extends PureComponent {
     target: PropTypes.number.isRequired,
   }
 
-  render() {
+  getOption() {
     const {
       source,
       target,
     } = this.props;
-    validate(source);
-
     const dataOption = getDataOption({
       source,
       defaultSeriesOpt: (index) => {
@@ -69,7 +67,7 @@ export default class TargetLine extends PureComponent {
       },
     });
 
-    const option = _.defaultsDeep({
+    return _.defaultsDeep({
       legend: {},
       tooltip: {
         trigger: 'axis',
@@ -85,9 +83,13 @@ export default class TargetLine extends PureComponent {
       xAxis: dataOption.axis,
       series: dataOption.series,
     });
+  }
+
+  render() {
+    validate(this.props.source);
 
     return (
-      <ReactEcharts option={option} {...this.props} />
+      <ReactEcharts option={this.getOption()} {...this.props} />
     );
   }
 }

--- a/ui/stories/line.stories.js
+++ b/ui/stories/line.stories.js
@@ -2,7 +2,26 @@ import React from 'react';
 import { storiesOf } from '../.storybook/facade';
 import Line from '../src/component/line';
 import TargetLine from '../src/component/target-line';
+import Cumulative from '../src/component/cumulative';
 import { timeSource } from './data';
+
+const cumulativeSource = [
+  ['time', 'Matcha Latte', 'Milk Tea', 'Cheese Cocoa', 'Walnut Brownie'],
+  ['2018/1', 43.3, 40, 16.4, 152.4],
+  ['2018/2', 85.8, 75, 35.2, 193.9],
+  ['2018/3', 93.7, 125, 62.5, 229.1],
+  ['2018/4', 103.7, 160, 152.5, 249.1],
+  ['2018/4', 113.7, 205, 265.5, 259.1],
+];
+
+const growthRateSource = [
+  ['time', 'ProductA', 'ProductB', 'ProductC'],
+  ['2018/1', 5, -5, 10],
+  ['2018/2', 3, 15, 8],
+  ['2018/3', 1, -10, 6],
+  ['2018/4', 3, 20, 4],
+  ['2018/5', 5, -5, 2],
+];
 
 storiesOf('Line Chart', module)
   .add('Simple line', () => (
@@ -10,4 +29,10 @@ storiesOf('Line Chart', module)
   ))
   .add('Target line', () => (
     <TargetLine target={80} source={timeSource} />
+  ))
+  .add('Cumulative', () => (
+    <Cumulative source={cumulativeSource} />
+  ))
+  .add('Growth rate', () => (
+    <Line source={growthRateSource} />
   ));


### PR DESCRIPTION
1. Refactor line chart to increase extensibility

2. Cumulative chart can be easily implemented by extending line component 
![image](https://user-images.githubusercontent.com/8684036/37567008-9dcff302-2afb-11e8-9c2b-089156329bb4.png)

3. Growth rate chart can be directly drawn by line component
![image](https://user-images.githubusercontent.com/8684036/37567014-ae5aece0-2afb-11e8-9f23-9219b0a19234.png)

